### PR TITLE
Changed getContentIfFile to return null when file does not exist

### DIFF
--- a/index.js
+++ b/index.js
@@ -148,7 +148,7 @@ function getContentIfFile(filepath){
 	if (fs.existsSync(filepath)) {
         return fs.readFileSync(filepath, 'utf8');
     }
-    return filepath;
+    return null;
 }
 
 


### PR DESCRIPTION
I was running into issues where empty arrays where getting returned when the file did not exist. The error was never thrown because getContentIfFile was returning the path string.  
